### PR TITLE
Revert <main> elements nested inside sections

### DIFF
--- a/src/components/CharityDetails.astro
+++ b/src/components/CharityDetails.astro
@@ -34,7 +34,7 @@ const bodyHTML = prismicH.asHTML(body)
 		<Fragment set:html='bodyHTML' />
 	</div>
 
-	<main>
+	<div>
 		<div class='footer-container'>
 			<p class='fundraiser-question'>
 				{questionText}{' '}
@@ -55,7 +55,7 @@ const bodyHTML = prismicH.asHTML(body)
 				}
 			</div>
 		</div>
-	</main>
+	</div>
 </section>
 
 <style>

--- a/src/components/CommunityList.astro
+++ b/src/components/CommunityList.astro
@@ -23,7 +23,7 @@ const bodyHTML = prismicH.asHTML(body)
 		<h2 id='communities-heading'>{heading}</h2>
 	</header>
 
-	<main>
+	<div>
 		<Fragment set:html='bodyHTML' />
 		<ul class='community-grid'>
 			{
@@ -36,7 +36,7 @@ const bodyHTML = prismicH.asHTML(body)
 				))
 			}
 		</ul>
-	</main>
+	</div>
 </section>
 
 <style lang='scss'>

--- a/src/components/EventDetails.astro
+++ b/src/components/EventDetails.astro
@@ -14,7 +14,7 @@ const bodyHTML = prismicH.asHTML(body)
 		<span class='heading-eyebrow'>{eyebrow}</span>
 		<h2 id='event-details-heading'>{heading}</h2>
 	</header>
-	<main>
+	<div>
 		<Fragment set:html='bodyHTML' />
-	</main>
+	</div>
 </section>

--- a/src/components/FAQ.astro
+++ b/src/components/FAQ.astro
@@ -22,7 +22,7 @@ const faqItems = items.map(item => {
 		<span class='heading-eyebrow'>{eyebrow}</span>
 		<h2 id='faq-heading'>{heading}</h2>
 	</header>
-	<main>
+	<div>
 		<Fragment set:html='bodyHTML' />
 		<div class='items'>
 			{
@@ -34,7 +34,7 @@ const faqItems = items.map(item => {
 				))
 			}
 		</div>
-	</main>
+	</div>
 </section>
 
 <style lang='scss'>

--- a/src/components/GuestList.astro
+++ b/src/components/GuestList.astro
@@ -30,7 +30,7 @@ const bodyHTML = prismicH.asHTML(body);
               avatar={guest.data.avatar}
               guestName={guest.data.name}
             />
-            <a class="name" accesskey="" href={`/guest/${guest.uid}`}>
+            <a class="name" href={`/guest/${guest.uid}`}>
               {guest.data.name}
             </a>
             <span class="company">{guest.data.company}</span>

--- a/src/components/GuestList.astro
+++ b/src/components/GuestList.astro
@@ -20,7 +20,7 @@ const bodyHTML = prismicH.asHTML(body);
     <h2 id="guests-heading">{heading}</h2>
   </header>
 
-  <main>
+  <div>
     <Fragment set:html="bodyHTML" />
     <div class="guest-grid">
       {
@@ -38,7 +38,7 @@ const bodyHTML = prismicH.asHTML(body);
         ))
       }
     </div>
-  </main>
+  </div>
 </section>
 
 <style lang="scss">

--- a/src/components/LastYearRecap.astro
+++ b/src/components/LastYearRecap.astro
@@ -15,9 +15,9 @@ const bodyHTML = prismicH.asHTML(body)
 		<h2 id='recap-heading'>{heading}</h2>
 	</header>
 
-	<main>
+	<div>
 		<Fragment set:html='bodyHTML' />
-	</main>
+	</div>
 </section>
 
 <style class='scss'>

--- a/src/components/SponsorList.astro
+++ b/src/components/SponsorList.astro
@@ -18,7 +18,7 @@ const bodyHTML = prismicH.asHTML(body)
 		<h2 id='sponsors-heading'>{heading}</h2>
 	</header>
 
-	<main>
+	<div>
 		<Fragment set:html='bodyHTML' />
 		<ul class='sponsor-grid'>
 			{
@@ -31,7 +31,7 @@ const bodyHTML = prismicH.asHTML(body)
 				))
 			}
 		</ul>
-	</main>
+	</div>
 </section>
 
 <style lang='scss'>

--- a/src/pages/guest/[uid].astro
+++ b/src/pages/guest/[uid].astro
@@ -37,7 +37,7 @@ const topicDescriptionHTML = prismicH.asHTML(topicDescription);
       <GuestAvatar avatar={avatar} guestName={name} />
       <h1>{name}</h1>
     </header>
-    <main>
+    <div>
       <div class="guest-details">
         <span>{jobTitle}</span>
         <span>{company}</span>
@@ -53,7 +53,7 @@ const topicDescriptionHTML = prismicH.asHTML(topicDescription);
           <Fragment set:html="topicDescriptionHTML" />
         </dd>
       </dl>
-    </main>
+    </div>
   </article>
 </Layout>
 


### PR DESCRIPTION
#30 added `<main>` elements to each section of the homepage. This doesn't align with [`<main>`'s intended use](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/main), which is to wrap the entire page's main contents. This change clutters up landmark-based screenreader navigation.

This PR goes through and replaces those `<main>`s with `<div>`s. I opted to have a wrapper `div` instead of removing the wrapper altogether because I figure the intent is to have a consistent wrapper for layout reasons.