### PR TITLE
Ensure hero image is NOT lazy loaded

### DIFF
--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -69,7 +69,7 @@ const bodyText = prismicH.asText(body);
         </div>
       </div>
       <div class="hero-column">
-        <Image src={placeholderImage} alt="" width={363} />
+        <Image src={placeholderImage} alt="" width={363} loading="eager" fetchpriority="high" />
       </div>
     </section>
     <div class="slice-container">


### PR DESCRIPTION
By default, Astro Image lazy loads images. This is fantastic for images below the fold, but less great for hero images. Here, I've explicitly reverted Astro Image's default behavior with `loading="eager"`, and then even put the `fetchpriority="high"` [priority hint](https://web.dev/priority-hints/) on it so it might just load even faster.