### PR TITLE
Refactor Slice prop Imports

### DIFF
--- a/src/components/CharityDetails.astro
+++ b/src/components/CharityDetails.astro
@@ -1,116 +1,107 @@
 ---
-import * as prismicH from '@prismicio/helpers'
-import { CharityDetailsSlice } from '../../types.generated'
-const props = Astro.props as CharityDetailsSlice
+import * as prismicH from '@prismicio/helpers';
+import { CharityDetailsSlice } from '../../types.generated';
 
-const {
-	heading,
-	body,
-	charityLogo,
-	eyebrow,
-	questionText,
-	fundraiserAmount,
-	subheading
-} = props.primary
+const slice = Astro.props.slice as CharityDetailsSlice;
 
-const { items } = props
-
-const bodyHTML = prismicH.asHTML(body)
+const bodyHTML = prismicH.asHTML(slice.primary.body);
 ---
 
-<section aria-labelledby='charity-heading' class='charity'>
-	<header>
-		<span class='heading-eyebrow'>{eyebrow}</span>
-		<h2 id='charity-heading' class='charity-heading'>{heading}</h2>
-	</header>
+<section aria-labelledby="charity-heading" class="charity">
+  <header>
+    <span class="heading-eyebrow">{slice.primary.eyebrow}</span>
+    <h2 id="charity-heading" class="charity-heading">
+      {slice.primary.heading}
+    </h2>
+  </header>
 
-	<div class='description-area'>
-		<img
-			src={charityLogo.url}
-			alt='Doctors without Borders'
-			class='charity-logo'
-		/>
-		<p class='subheading'>{subheading}</p>
-		<Fragment set:html='bodyHTML' />
-	</div>
+  <div class="description-area">
+    <img
+      src={slice.primary.charityLogo.url}
+      alt="Doctors without Borders"
+      class="charity-logo"
+    />
+    <p class="subheading">{slice.primary.subheading}</p>
+    <Fragment set:html="bodyHTML" />
+  </div>
 
-	<div>
-		<div class='footer-container'>
-			<p class='fundraiser-question'>
-				{questionText}{' '}
-				<span class='fundraiser-amount'>
-					{fundraiserAmount}
-				</span>
-			</p>
-			<div class='impact-container'>
-				{
-					items.map(({ number, text }) => (
-						<div class='impact-item'>
-							<p class='impact-text'>
-								<span class='impact-number'>{number}</span>
-								<span>{text}</span>
-							</p>
-						</div>
-					))
-				}
-			</div>
-		</div>
-	</div>
+  <div>
+    <div class="footer-container">
+      <p class="fundraiser-question">
+        {slice.primary.questionText}{' '}
+        <span class="fundraiser-amount">
+          {slice.primary.fundraiserAmount}
+        </span>
+      </p>
+      <div class="impact-container">
+        {
+          slice.items.map(({ number, text }) => (
+            <div class="impact-item">
+              <p class="impact-text">
+                <span class="impact-number">{number}</span>
+                <span>{text}</span>
+              </p>
+            </div>
+          ))
+        }
+      </div>
+    </div>
+  </div>
 </section>
 
 <style>
-	.charity-heading {
-		margin-bottom: var(--space-m);
-		display: block;
-	}
+  .charity-heading {
+    margin-bottom: var(--space-m);
+    display: block;
+  }
 
-	.charity-logo {
-		max-width: 500px;
-		margin-bottom: var(--space-l);
-	}
+  .charity-logo {
+    max-width: 500px;
+    margin-bottom: var(--space-l);
+  }
 
-	.description-area {
-		margin-bottom: var(--space-xl);
-	}
+  .description-area {
+    margin-bottom: var(--space-xl);
+  }
 
-	.subheading {
-		font-weight: 700;
-		margin-bottom: var(--space-2xs);
-	}
+  .subheading {
+    font-weight: 700;
+    margin-bottom: var(--space-2xs);
+  }
 
-	.footer-container {
-	}
+  .footer-container {
+  }
 
-	.fundraiser-amount {
-		display: block;
-		font-size: var(--step-5);
-		font-weight: 700;
-		margin-bottom: var(--space-s);
-	}
+  .fundraiser-amount {
+    display: block;
+    font-size: var(--step-5);
+    font-weight: 700;
+    margin-bottom: var(--space-s);
+  }
 
-	.impact-container {
-		--min: 20ch;
-		--gap: var(--space-m);
+  .impact-container {
+    --min: 20ch;
+    --gap: var(--space-m);
 
-		display: grid;
-		grid-gap: var(--gap);
-		grid-template-columns: repeat(auto-fit, minmax(min(100%, var(--min)), 1fr));
+    display: grid;
+    grid-gap: var(--gap);
+    grid-template-columns: repeat(auto-fit, minmax(min(100%, var(--min)), 1fr));
 
-		font-size: var(--step--1);
-	}
+    font-size: var(--step--1);
+  }
 
-	.impact-text {
-		font-size: var(--step--1);
-		display: flex;
-		gap: var(--space-xs);
-		font-weight: 500;
-		> * {
-			display: block;
-		}
-	}
+  .impact-text {
+    font-size: var(--step--1);
+    display: flex;
+    gap: var(--space-xs);
+    font-weight: 500;
+    > * {
+      display: block;
+    }
+  }
 
-	.impact-number {
-		font-size: var(--step-3);
-		font-weight: 700;
-	}
+  .impact-number {
+    font-size: var(--step-3);
+    font-weight: 700;
+  }
 </style>

--- a/src/components/CommunityList.astro
+++ b/src/components/CommunityList.astro
@@ -1,80 +1,77 @@
 ---
-import * as prismicH from '@prismicio/helpers'
-import { getAllCommunitySponsors } from '../lib/prismicio'
+import * as prismicH from '@prismicio/helpers';
+import { getAllCommunitySponsors } from '../lib/prismicio';
+import { CommunityListSlice } from '../../types.generated';
 
-import { CommunityListSlice } from '../../types.generated'
+const slice = Astro.props.slice as CommunityListSlice;
 
-const props = Astro.props as CommunityListSlice
+const communities = await getAllCommunitySponsors();
 
-const { heading, body, eyebrow } = props.primary
-
-const communities = await getAllCommunitySponsors()
-
-const bodyHTML = prismicH.asHTML(body)
+const bodyHTML = prismicH.asHTML(slice.primary.body);
 ---
 
 <section
-	id='communities'
-	aria-labelledby='communities-heading'
-	class='communities'
+  id="communities"
+  aria-labelledby="communities-heading"
+  class="communities"
 >
-	<header>
-		<span class='heading-eyebrow'>{eyebrow}</span>
-		<h2 id='communities-heading'>{heading}</h2>
-	</header>
+  <header>
+    <span class="heading-eyebrow">{slice.primary.eyebrow}</span>
+    <h2 id="communities-heading">{slice.primary.heading}</h2>
+  </header>
 
-	<div>
-		<Fragment set:html='bodyHTML' />
-		<ul class='community-grid'>
-			{
-				communities.map(community => (
-					<li class='community'>
-						<a href={`/community/${community.uid}`}>
-							<img src={community.data.logo.url} alt={community.data.title} />
-						</a>
-					</li>
-				))
-			}
-		</ul>
-	</div>
+  <div>
+    <Fragment set:html="bodyHTML" />
+    <ul class="community-grid">
+      {
+        communities.map((community) => (
+          <li class="community">
+            <a href={`/community/${community.uid}`}>
+              <img src={community.data.logo.url} alt={community.data.title} />
+            </a>
+          </li>
+        ))
+      }
+    </ul>
+  </div>
 </section>
 
-<style lang='scss'>
-	.communities {
-		.community-grid {
-			display: grid;
-			grid-template-columns: repeat(auto-fit, minmax(20ch, 1fr));
-			grid-gap: var(--space-s);
-		}
+<style lang="scss">
+  .communities {
+    .community-grid {
+      display: grid;
+      grid-template-columns: repeat(auto-fit, minmax(20ch, 1fr));
+      grid-gap: var(--space-s);
+    }
 
-		.community {
-			position: relative;
-			background: rgba(0, 0, 0, 0.25);
-			padding-block: var(--space-xs);
-			padding-inline: var(--space-s);
-			display: grid;
-			place-content: center;
-			transition: background 0.2s ease;
-			border-radius: 0.5rem;
-			&:hover {
-				background: rgba(0, 0, 0, 0.3);
-			}
-			a {
-				&::before {
-					content: '';
-					position: absolute;
-					inset: 0;
-				}
-			}
-			img {
-				display: block;
-				max-width: 100%;
-				padding: 0;
-				margin: 0;
-				width: auto;
-				height: 100px;
-				object-fit: contain;
-			}
-		}
-	}
+    .community {
+      position: relative;
+      background: rgba(0, 0, 0, 0.25);
+      padding-block: var(--space-xs);
+      padding-inline: var(--space-s);
+      display: grid;
+      place-content: center;
+      transition: background 0.2s ease;
+      border-radius: 0.5rem;
+      &:hover {
+        background: rgba(0, 0, 0, 0.3);
+      }
+      a {
+        &::before {
+          content: '';
+          position: absolute;
+          inset: 0;
+        }
+      }
+      img {
+        display: block;
+        max-width: 100%;
+        padding: 0;
+        margin: 0;
+        width: auto;
+        height: 100px;
+        object-fit: contain;
+      }
+    }
+  }
 </style>

--- a/src/components/EventDetails.astro
+++ b/src/components/EventDetails.astro
@@ -1,20 +1,18 @@
 ---
-import * as prismicH from '@prismicio/helpers'
-import { EventDetailsSlice } from '../../types.generated'
+import * as prismicH from '@prismicio/helpers';
+import { EventDetailsSlice } from '../../types.generated';
 
-const props = Astro.props as EventDetailsSlice
+const slice = Astro.props.slice as EventDetailsSlice;
 
-const { heading, body, dateTime, showLink, eyebrow } = props.primary
-
-const bodyHTML = prismicH.asHTML(body)
+const bodyHTML = prismicH.asHTML(slice.primary.body);
 ---
 
-<section aria-labelledby='event-details-heading' class='event'>
-	<header>
-		<span class='heading-eyebrow'>{eyebrow}</span>
-		<h2 id='event-details-heading'>{heading}</h2>
-	</header>
-	<div>
-		<Fragment set:html='bodyHTML' />
-	</div>
+<section aria-labelledby="event-details-heading" class="event">
+  <header>
+    <span class="heading-eyebrow">{slice.primary.eyebrow}</span>
+    <h2 id="event-details-heading">{slice.primary.heading}</h2>
+  </header>
+  <div>
+    <Fragment set:html="bodyHTML" />
+  </div>
 </section>

--- a/src/components/FAQ.astro
+++ b/src/components/FAQ.astro
@@ -1,50 +1,48 @@
 ---
-import * as prismicH from '@prismicio/helpers'
+import * as prismicH from '@prismicio/helpers';
 
-import { FrequentlyAskedQuestionsSlice } from '../../types.generated'
+import { FrequentlyAskedQuestionsSlice } from '../../types.generated';
 
-const props = Astro.props as FrequentlyAskedQuestionsSlice
-const { heading, body, eyebrow } = props.primary
-const { items } = props
+const slice = Astro.props.slice as FrequentlyAskedQuestionsSlice;
 
-const bodyHTML = prismicH.asHTML(body)
+const bodyHTML = prismicH.asHTML(slice.primary.body);
 
-const faqItems = items.map(item => {
-	return {
-		heading: item.heading,
-		body: prismicH.asHTML(item.body)
-	}
-})
+const faqItems = slice.items.map((item) => {
+  return {
+    heading: item.heading,
+    body: prismicH.asHTML(item.body),
+  };
+});
 ---
 
-<section aria-labelledby='faq-heading' class='faq'>
-	<header>
-		<span class='heading-eyebrow'>{eyebrow}</span>
-		<h2 id='faq-heading'>{heading}</h2>
-	</header>
-	<div>
-		<Fragment set:html='bodyHTML' />
-		<div class='items'>
-			{
-				faqItems.map(item => (
-					<details>
-						<summary>{item.heading}</summary>
-						<Fragment set:html='item.body' />
-					</details>
-				))
-			}
-		</div>
-	</div>
+<section aria-labelledby="faq-heading" class="faq">
+  <header>
+    <span class="heading-eyebrow">{slice.primary.eyebrow}</span>
+    <h2 id="faq-heading">{slice.primary.heading}</h2>
+  </header>
+  <div>
+    <Fragment set:html="bodyHTML" />
+    <div class="items">
+      {
+        faqItems.map((item) => (
+          <details>
+            <summary>{item.heading}</summary>
+            <Fragment set:html="item.body" />
+          </details>
+        ))
+      }
+    </div>
+  </div>
 </section>
 
-<style lang='scss'>
-	.items {
-		display: grid;
-		gap: var(--space-xs);
-	}
-	details {
-		summary {
-			margin-bottom: var(--space-2xs);
-		}
-	}
+<style lang="scss">
+  .items {
+    display: grid;
+    gap: var(--space-xs);
+  }
+  details {
+    summary {
+      margin-bottom: var(--space-2xs);
+    }
+  }
 </style>

--- a/src/components/GuestAvatar.astro
+++ b/src/components/GuestAvatar.astro
@@ -1,21 +1,27 @@
 ---
 import * as prismicH from '@prismicio/helpers';
+import { GuestDocument } from '../../types.generated';
 // We might want to take certain props for when it's
 // on the homepage or on the Guest's individual page.
 
-const props = Astro.props;
+const guest = Astro.props.guest as GuestDocument;
+console.log('🚀 ~ file: GuestAvatar.astro:8 ~ guest', guest);
 
-const avatarURL = prismicH.asImageSrc(props.avatar, {
+const avatarURL = prismicH.asImageSrc(guest.data.avatar, {
   w: 300,
   h: 300,
   fit: 'crop',
-  crop: 'faces',
 });
 // console.log('🚀 ~ file: GuestAvatar.astro ~ line 14 ~ avatarURL', avatarURL);
 ---
 
 <div class="guest-avatar">
-  <img src={avatarURL} alt={`Headshot of ${props.guestName}`} width={300} height={300} />
+  <img
+    src={avatarURL}
+    alt={`Headshot of ${guest.data.name}`}
+    width={300}
+    height={300}
+  />
 </div>
 
 <style lang="scss">

--- a/src/components/GuestList.astro
+++ b/src/components/GuestList.astro
@@ -4,20 +4,18 @@ import { getAllGuests } from '../lib/prismicio';
 import GuestAvatar from './GuestAvatar.astro';
 import { GuestListSlice } from '../../types.generated';
 
-const props = Astro.props as GuestListSlice;
-
-const { heading, body, eyebrow } = props.primary;
+const slice = Astro.props.slice as GuestListSlice;
 
 // Fetch guests and map to order from CMS
 const allGuests = await getAllGuests();
 
-const bodyHTML = prismicH.asHTML(body);
+const bodyHTML = prismicH.asHTML(slice.primary.body);
 ---
 
 <section id="guests" aria-labelledby="guests-heading" class="guests">
   <header>
-    <span class="heading-eyebrow">{eyebrow}</span>
-    <h2 id="guests-heading">{heading}</h2>
+    <span class="heading-eyebrow">{slice.primary.eyebrow}</span>
+    <h2 id="guests-heading">{slice.primary.heading}</h2>
   </header>
 
   <div>
@@ -26,10 +24,7 @@ const bodyHTML = prismicH.asHTML(body);
       {
         allGuests.map((guest) => (
           <article class="guest">
-            <GuestAvatar
-              avatar={guest.data.avatar}
-              guestName={guest.data.name}
-            />
+            <GuestAvatar guest={guest} />
             <a class="name" href={`/guest/${guest.uid}`}>
               {guest.data.name}
             </a>

--- a/src/components/LastYearRecap.astro
+++ b/src/components/LastYearRecap.astro
@@ -1,29 +1,27 @@
 ---
-import * as prismicH from '@prismicio/helpers'
+import * as prismicH from '@prismicio/helpers';
 
-import { LastYearRecapSlice } from '../../types.generated'
+import { LastYearRecapSlice } from '../../types.generated';
 
-const props = Astro.props as LastYearRecapSlice
+const slice = Astro.props.slice as LastYearRecapSlice;
 
-const { heading, body } = props.primary
-
-const bodyHTML = prismicH.asHTML(body)
+const bodyHTML = prismicH.asHTML(slice.primary.body);
 ---
 
-<section aria-labelledby='recap-heading' class='recap'>
-	<header>
-		<h2 id='recap-heading'>{heading}</h2>
-	</header>
+<section aria-labelledby="recap-heading" class="recap">
+  <header>
+    <h2 id="recap-heading">{slice.primary.heading}</h2>
+  </header>
 
-	<div>
-		<Fragment set:html='bodyHTML' />
-	</div>
+  <div>
+    <Fragment set:html="bodyHTML" />
+  </div>
 </section>
 
-<style class='scss'>
-	.recap {
-		> * + * {
-			margin-block-start: var(--space-s);
-		}
-	}
+<style class="scss">
+  .recap {
+    > * + * {
+      margin-block-start: var(--space-s);
+    }
+  }
 </style>

--- a/src/components/RegisterCTA.astro
+++ b/src/components/RegisterCTA.astro
@@ -1,19 +1,17 @@
 ---
-import RegistrationButton from "./RegistrationButton.astro";
-import { RegisterCtaSlice } from "../../types.generated";
+import RegistrationButton from './RegistrationButton.astro';
+import { RegisterCtaSlice } from '../../types.generated';
 
-const props = Astro.props as RegisterCtaSlice;
-
-const { bottomText, buttontext, topText } = props.primary;
+const slice = Astro.props.slice as RegisterCtaSlice;
 ---
 
 <section class="registration">
   <h2>
-    <span>{topText}</span>
-    <span>{bottomText}</span>
+    <span>{slice.primary.topText}</span>
+    <span>{slice.primary.bottomText}</span>
   </h2>
 
-  <RegistrationButton>{buttontext}</RegistrationButton>
+  <RegistrationButton>{slice.primary.buttontext}</RegistrationButton>
 </section>
 
 <style lang="scss">

--- a/src/components/SliceZone.astro
+++ b/src/components/SliceZone.astro
@@ -1,14 +1,14 @@
 ---
-import GuestList from "./GuestList.astro";
+import GuestList from './GuestList.astro';
 
-import SponsorList from "./SponsorList.astro";
-import RegisterCTA from "./RegisterCTA.astro";
-import CharityDetails from "./CharityDetails.astro";
-import EventDetails from "./EventDetails.astro";
-import LastYearRecap from "./LastYearRecap.astro";
-import DonationLeaderboard from "./DonationLeaderboard.astro";
-import CommunityList from "./CommunityList.astro";
-import FAQ from "./FAQ.astro";
+import SponsorList from './SponsorList.astro';
+import RegisterCTA from './RegisterCTA.astro';
+import CharityDetails from './CharityDetails.astro';
+import EventDetails from './EventDetails.astro';
+import LastYearRecap from './LastYearRecap.astro';
+import DonationLeaderboard from './DonationLeaderboard.astro';
+import CommunityList from './CommunityList.astro';
+import FAQ from './FAQ.astro';
 
 const components = {
   guest_list: GuestList,
@@ -31,7 +31,7 @@ const { slices } = Astro.props;
   {
     slices.map((slice, index) => {
       const Component = components[slice.slice_type];
-      return <Component key={index} {...slice} />;
+      return <Component key={index} slice={slice} />;
     })
   }
 </>

--- a/src/components/SponsorList.astro
+++ b/src/components/SponsorList.astro
@@ -1,75 +1,73 @@
 ---
-import * as prismicH from '@prismicio/helpers'
-import { getAllSponsors } from '../lib/prismicio'
-import { SponsorListSlice } from '../../types.generated'
+import * as prismicH from '@prismicio/helpers';
+import { getAllSponsors } from '../lib/prismicio';
+import { SponsorListSlice } from '../../types.generated';
 
-const props = Astro.props as SponsorListSlice
+const slice = Astro.props.slice as SponsorListSlice;
 
-const { heading, body, eyebrow } = props.primary
+const sponsors = await getAllSponsors();
 
-const sponsors = await getAllSponsors()
-
-const bodyHTML = prismicH.asHTML(body)
+const bodyHTML = prismicH.asHTML(slice.primary.body);
 ---
 
-<section id='sponsors' aria-labelledby='sponsors-heading' class='sponsors'>
-	<header>
-		<span class='heading-eyebrow'>{eyebrow}</span>
-		<h2 id='sponsors-heading'>{heading}</h2>
-	</header>
+<section id="sponsors" aria-labelledby="sponsors-heading" class="sponsors">
+  <header>
+    <span class="heading-eyebrow">{slice.primary.eyebrow}</span>
+    <h2 id="sponsors-heading">{slice.primary.heading}</h2>
+  </header>
 
-	<div>
-		<Fragment set:html='bodyHTML' />
-		<ul class='sponsor-grid'>
-			{
-				sponsors.map(sponsor => (
-					<li class='sponsor'>
-						<a href={`/sponsor/${sponsor.uid}`}>
-							<img src={sponsor.data.logo.url} alt={sponsor.data.name} />
-						</a>
-					</li>
-				))
-			}
-		</ul>
-	</div>
+  <div>
+    <Fragment set:html="bodyHTML" />
+    <ul class="sponsor-grid">
+      {
+        sponsors.map((sponsor) => (
+          <li class="sponsor">
+            <a href={`/sponsor/${sponsor.uid}`}>
+              <img src={sponsor.data.logo.url} alt={sponsor.data.name} />
+            </a>
+          </li>
+        ))
+      }
+    </ul>
+  </div>
 </section>
 
-<style lang='scss'>
-	.sponsors {
-		.sponsor-grid {
-			display: grid;
-			grid-template-columns: repeat(auto-fit, minmax(15ch, 1fr));
-			grid-gap: var(--space-s);
-		}
+<style lang="scss">
+  .sponsors {
+    .sponsor-grid {
+      display: grid;
+      grid-template-columns: repeat(auto-fit, minmax(15ch, 1fr));
+      grid-gap: var(--space-s);
+    }
 
-		.sponsor {
-			position: relative;
-			background: rgba(0, 0, 0, 0.25);
-			padding-block: var(--space-s);
-			padding-inline: var(--space-s-m);
-			display: grid;
-			place-content: center;
-			transition: background 0.2s ease;
-			border-radius: 0.5rem;
-			&:hover {
-				background: rgba(0, 0, 0, 0.3);
-			}
-			a {
-				&::before {
-					content: '';
-					position: absolute;
-					inset: 0;
-				}
-			}
-			img {
-				display: block;
-				max-width: 100%;
-				padding: 0;
-				margin: 0;
-				width: auto;
-				height: 100px;
-				object-fit: contain;
-			}
-		}
-	}
+    .sponsor {
+      position: relative;
+      background: rgba(0, 0, 0, 0.25);
+      padding-block: var(--space-s);
+      padding-inline: var(--space-s-m);
+      display: grid;
+      place-content: center;
+      transition: background 0.2s ease;
+      border-radius: 0.5rem;
+      &:hover {
+        background: rgba(0, 0, 0, 0.3);
+      }
+      a {
+        &::before {
+          content: '';
+          position: absolute;
+          inset: 0;
+        }
+      }
+      img {
+        display: block;
+        max-width: 100%;
+        padding: 0;
+        margin: 0;
+        width: auto;
+        height: 100px;
+        object-fit: contain;
+      }
+    }
+  }
 </style>

--- a/src/pages/contributors.astro
+++ b/src/pages/contributors.astro
@@ -1,23 +1,29 @@
 ---
-import Layout from "../layouts/Layout.astro";
-import { getOrganizers } from "../lib/prismicio";
-import * as prismicH from "@prismicio/helpers";
+import Layout from '../layouts/Layout.astro';
+import { getOrganizers } from '../lib/prismicio';
+import * as prismicH from '@prismicio/helpers';
+import { OrganizerTeamDocumentDataMemberItem } from '../../types.generated';
 
 const organizers = await getOrganizers();
 
 const bodyHTML = prismicH.asHTML(organizers.data.body);
 ---
 
-<Layout title="Donations - Holiday Snowtacular - Web Dev Charity Fundraiser">
+<Layout
+  title="Donations - Holiday Snowtacular - Web Dev Charity Fundraiser"
+  description={`A list of the wonderful organizers for the 2022 Holiday Snowtacular!`}
+>
   <h1>{organizers.data.heading}</h1>
   <Fragment set:html="bodyHTML" />
   {
-    organizers.data.member.map((member) => (
-      <div>
-        <p>{member.name}</p>
-        <p>{member.contributions}</p>
-        <a href={member.websiteURL}>Website</a>
-      </div>
-    ))
+    organizers.data.member.map(
+      (member: OrganizerTeamDocumentDataMemberItem) => (
+        <div>
+          <p>{member.name}</p>
+          <p>{member.contributions}</p>
+          <a href={member.websiteURL}>Website</a>
+        </div>
+      )
+    )
   }
 </Layout>

--- a/src/pages/donations.astro
+++ b/src/pages/donations.astro
@@ -1,10 +1,13 @@
 ---
-import DonationGrid from "../components/DonationGrid.svelte";
-import Layout from "../layouts/Layout.astro";
+import DonationGrid from '../components/DonationGrid.svelte';
+import Layout from '../layouts/Layout.astro';
 // Fetch Donations from API
 ---
 
-<Layout title="Donations - Holiday Snowtacular - Web Dev Charity Fundraiser">
+<Layout
+  title="Donations - Holiday Snowtacular - Web Dev Charity Fundraiser"
+  description={`The full list of donations from the 2022 Holiday Snowtacular.`}
+>
   <h1>Donations</h1>
   <DonationGrid client:load />
 </Layout>

--- a/src/pages/guest/[uid].astro
+++ b/src/pages/guest/[uid].astro
@@ -1,9 +1,9 @@
 ---
 import * as prismicH from '@prismicio/helpers';
 import Layout from '../../layouts/Layout.astro';
-import SliceZone from '../../components/SliceZone.astro';
 import { getAllGuests } from '../../lib/prismicio';
 import GuestAvatar from '../../components/GuestAvatar.astro';
+import { GuestDocument } from '../../../types.generated';
 
 export async function getStaticPaths() {
   const allPages = await getAllGuests();
@@ -14,33 +14,25 @@ export async function getStaticPaths() {
   return paths;
 }
 
-const {
-  name,
-  avatar,
-  jobTitle,
-  company,
-  guestBio,
-  twitterUrl,
-  websiteUrl,
-  mastadonUrl,
-  topicTitle,
-  topicDescription,
-} = Astro.props.data;
+const guest = Astro.props as GuestDocument;
 
-const guestBioHTML = prismicH.asHTML(guestBio);
-const topicDescriptionHTML = prismicH.asHTML(topicDescription);
+const guestBioHTML = prismicH.asHTML(guest.data.guestBio);
+const topicDescriptionHTML = prismicH.asHTML(guest.data.topicDescription);
 ---
 
-<Layout title={`${name} - Guest Speaker - Holiday Snowtacular`}>
+<Layout
+  title={`${guest.data.name} - Guest Speaker - Holiday Snowtacular`}
+  description={`${guest.data.name} is a guest speaker at the 2022 Holiday Snowtacular`}
+>
   <article id="guest-page">
     <header>
-      <GuestAvatar avatar={avatar} guestName={name} />
-      <h1>{name}</h1>
+      <GuestAvatar guest={guest} />
+      <h1>{guest.data.name}</h1>
     </header>
     <div>
       <div class="guest-details">
-        <span>{jobTitle}</span>
-        <span>{company}</span>
+        <span>{guest.data.jobTitle}</span>
+        <span>{guest.data.company}</span>
       </div>
       <dl>
         <dt>Bio</dt>
@@ -48,7 +40,7 @@ const topicDescriptionHTML = prismicH.asHTML(topicDescription);
           <Fragment set:html="guestBioHTML" />
         </dd>
         <dt>Topic</dt>
-        <dd>{topicTitle}</dd>
+        <dd>{guest.data.topicTitle}</dd>
         <dd>
           <Fragment set:html="topicDescriptionHTML" />
         </dd>

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -12,19 +12,9 @@ import HolidaySnowtacularLogo from '../components/HolidaySnowtacularLogo.astro';
 import RegistrationButton from '../components/RegistrationButton.astro';
 
 const page = await getHomepage();
-const {
-  body,
-  title,
-  buttonText,
-  ctaDescription,
-  heroEyebrow,
-  metadescription,
-  metatitle,
-  ogImage,
-  slices,
-} = page.data;
-const bodyHTML = prismicH.asHTML(body);
-const bodyText = prismicH.asText(body);
+
+const bodyHTML = prismicH.asHTML(page.data.body);
+const bodyText = prismicH.asText(page.data.body);
 ---
 
 <Layout
@@ -36,7 +26,7 @@ const bodyText = prismicH.asText(body);
       <div class="hero-column">
         <div class="kicker">
           {
-            heroEyebrow.map((item, i) => (
+            page.data.heroEyebrow.map((item, i) => (
               <>
                 {i > 0 ? <span class="spacer"> | </span> : ''}
 
@@ -54,9 +44,9 @@ const bodyText = prismicH.asText(body);
         </div>
 
         <div class="cta">
-          <p class="cta-description">{ctaDescription}</p>
+          <p class="cta-description">{page.data.ctaDescription}</p>
           <RegistrationButton>
-            {buttonText}
+            {page.data.buttonText}
             <span class="icon">
               <svg viewBox="0 0 17 16" fill="none" role="presentation">
                 <path
@@ -69,11 +59,17 @@ const bodyText = prismicH.asText(body);
         </div>
       </div>
       <div class="hero-column">
-        <Image src={placeholderImage} alt="" width={363} loading="eager" fetchpriority="high" />
+        <Image
+          src={placeholderImage}
+          alt=""
+          width={363}
+          loading="eager"
+          fetchpriority="high"
+        />
       </div>
     </section>
     <div class="slice-container">
-      <SliceZone slices={slices} />
+      <SliceZone slices={page.data.slices} />
     </div>
   </main>
 </Layout>

--- a/src/pages/sponsor/[uid].astro
+++ b/src/pages/sponsor/[uid].astro
@@ -1,9 +1,9 @@
 ---
-import * as prismicH from "@prismicio/helpers";
-import Layout from "../../layouts/Layout.astro";
+import * as prismicH from '@prismicio/helpers';
+import Layout from '../../layouts/Layout.astro';
 
-import { getAllSponsors } from "../../lib/prismicio";
-import { SponsorDocument } from "../../../types.generated";
+import { getAllSponsors } from '../../lib/prismicio';
+import { SponsorDocument } from '../../../types.generated';
 
 export async function getStaticPaths() {
   const allPages = await getAllSponsors();
@@ -15,21 +15,27 @@ export async function getStaticPaths() {
   return paths;
 }
 
-const props = Astro.props as SponsorDocument;
+const sponsor = Astro.props as SponsorDocument;
 
-const { name, link, logo, description } = props.data;
-
-const descriptionHTML = prismicH.asHTML(description);
+const descriptionHTML = prismicH.asHTML(sponsor.data.description);
 ---
 
-<Layout title={`${name} - Guest Speaker - Holiday Snowtacular`}>
+<Layout
+  title={`${sponsor.data.name} - Guest Speaker - Holiday Snowtacular`}
+  description={`${sponsor.data.name} is sponsoring the 2022 Holiday Snowtacular in an effort to raise $20,000 for Doctors Without Borders!`}
+>
   <main>
-    <h1>{name}</h1>
-    <img src={logo.url} alt="" />
+    <h1>{sponsor.data.name}</h1>
+    <img src={sponsor.data.logo.url} alt="" />
     <Fragment set:html="descriptionHTML" />
-    <p>
-      <a href={link.url}>Visit Site</a>
-    </p>
+
+    {
+      prismicH.isFilled.link(sponsor.data.link) && (
+        <p>
+          <a href={sponsor.data.link.url}>Visit Site</a>
+        </p>
+      )
+    }
   </main>
 </Layout>
 


### PR DESCRIPTION
Instead of spreading slice props in `SliceZone.astro` we now pass `slice={slice}`, type the props inside the slice components, and keep context throughout the component with chains like `{slice.primary.heading}`

Credit to Angelo Ashmore for suggesting the refactor.