### PR TITLE
Qualify outgoing sponsor link with `rel` attribute

### DIFF
--- a/src/components/SponsorList.astro
+++ b/src/components/SponsorList.astro
@@ -22,7 +22,7 @@ const bodyHTML = prismicH.asHTML(slice.primary.body);
       {
         sponsors.map((sponsor) => (
           <li class="sponsor">
-            <a href={`/sponsor/${sponsor.uid}`} rel="sponsored">
+            <a href={`/sponsor/${sponsor.uid}`}>
               <img src={sponsor.data.logo.url} alt={sponsor.data.name} />
             </a>
           </li>

--- a/src/components/SponsorList.astro
+++ b/src/components/SponsorList.astro
@@ -22,7 +22,7 @@ const bodyHTML = prismicH.asHTML(slice.primary.body);
       {
         sponsors.map((sponsor) => (
           <li class="sponsor">
-            <a href={`/sponsor/${sponsor.uid}`}>
+            <a href={`/sponsor/${sponsor.uid}`} rel="sponsored">
               <img src={sponsor.data.logo.url} alt={sponsor.data.name} />
             </a>
           </li>

--- a/src/pages/sponsor/[uid].astro
+++ b/src/pages/sponsor/[uid].astro
@@ -32,7 +32,7 @@ const descriptionHTML = prismicH.asHTML(sponsor.data.description);
     {
       prismicH.isFilled.link(sponsor.data.link) && (
         <p>
-          <a href={sponsor.data.link.url}>Visit Site</a>
+          <a href={sponsor.data.link.url} rel="sponsored">Visit Site</a>
         </p>
       )
     }


### PR DESCRIPTION
The [`rel="sponsored"`](https://developers.google.com/search/docs/crawling-indexing/qualify-outbound-links) attribute is a way to indicate to Google that a link's presence on a site was paid for. Appropriately flagging this decreases the odds that Google treats our links out to various tech companies as spammy (unlikely that they would, but better safe than sorry!)

Bonus: `[rel*="sponsored"]` is a lovely [semantic selector](https://benmyers.dev/blog/semantic-selectors/)