### PR TITLE
Fix sponsor logo in Firefox

### DIFF
--- a/src/pages/sponsor/[uid].astro
+++ b/src/pages/sponsor/[uid].astro
@@ -124,9 +124,7 @@ const descriptionHTML = prismicH.asHTML(sponsor.data.description);
   }
 
   .holiday-supporter-logo-container > img {
-    max-width: 500px;
-    max-height: 300px;
-    width: 100%;
+    width: 250px;
     height: auto;
   }
 


### PR DESCRIPTION
Silly Firefox apparently needs an explicit height or width set on SVG images.