### PR TITLE
Provide gray outline for sponsor link to improve contrast

### DIFF
--- a/src/pages/sponsor/[uid].astro
+++ b/src/pages/sponsor/[uid].astro
@@ -41,7 +41,7 @@ const descriptionHTML = prismicH.asHTML(sponsor.data.description);
     {
       prismicH.isFilled.link(sponsor.data.ctalink) && (
         <div class="holiday-supporter-cta">
-          <a class="button" data-variant="red" href={sponsor.data.ctalink.url}>
+          <a class="button" href={sponsor.data.ctalink.url}>
             {sponsor.data.ctalabel}
           </a>
         </div>
@@ -178,5 +178,9 @@ const descriptionHTML = prismicH.asHTML(sponsor.data.description);
       grid-template-columns: 1fr 2fr;
       gap: var(--space-s-m) var(--space-l-xl);
     }
+  }
+
+  a.button {
+    outline: 2px solid var(--gray-6);
   }
 </style>

--- a/src/pages/sponsor/[uid].astro
+++ b/src/pages/sponsor/[uid].astro
@@ -180,7 +180,7 @@ const descriptionHTML = prismicH.asHTML(sponsor.data.description);
     }
   }
 
-  a.button {
+  .button {
     outline: 2px solid var(--gray-6);
   }
 </style>

--- a/src/styles/theme.scss
+++ b/src/styles/theme.scss
@@ -1,3 +1,4 @@
+@import 'open-props/gray';
 @import 'open-props/blue';
 @import 'open-props/red';
 


### PR DESCRIPTION
On each sponsor's page, the gray "Visit [sponsor]" link has a poor contrast ratio against the navy part of the background gradient it's against.

<img width="161" alt="Dark gray 'Visit Clerk' button against a navy background" src="https://user-images.githubusercontent.com/18060369/206038441-0a41bca1-a473-47b1-a520-da7d4e04de60.png">

[UI controls should meet a 3:1 ratio against their background](https://www.w3.org/WAI/WCAG21/Understanding/non-text-contrast.html) - I measured about a 1.17:1 ratio.

To fix this, instead of setting the button-link to red and conflicting with the navbar CTA, and instead of inventing a whole new CTA color, I just added a middle-gray outline around the button, which makes this conformant.

<img width="161" alt="Dark gray 'Visit Clerk' button with a lighter gray outline against a navy background" src="https://user-images.githubusercontent.com/18060369/206039015-3f9966b6-cf5b-475a-9db7-18f8202f5082.png">

New ratios:
* **Button gray background against light gray outline:** 4.32:1
* **Light gray outline against navy page background:** 5.05:1 (not exact, because gradients)