### PR TITLE
Add `color-scheme: light` to registration section for better contrast

### DIFF
--- a/src/components/RegisterCTA.astro
+++ b/src/components/RegisterCTA.astro
@@ -22,6 +22,7 @@ const slice = Astro.props.slice as RegisterCtaSlice;
     display: grid;
     place-items: center;
     gap: var(--space-m);
+    color-scheme: light;
   }
 
   h2 {


### PR DESCRIPTION
The focus outline defaults to `Highlight` which changes based on `color-scheme`. This PR makes it so that the light theme `Highlight` is used, which contrasts better against a light background.

| Before | After |
| --- | --- |
| ![](https://user-images.githubusercontent.com/9084735/206053832-dfe21eb7-4de6-42a8-9e61-d08488cdf431.png)  | ![](https://user-images.githubusercontent.com/9084735/206053674-cd152fd3-c9b9-4c2e-8f25-ae036fd93c69.png) |