### PR TITLE
Remove root font size override

### DIFF
--- a/src/styles/typography.scss
+++ b/src/styles/typography.scss
@@ -27,10 +27,6 @@
   --header-font: 'Recoleta-Medium', serif;
 }
 
-html {
-  font-size: 16px;
-}
-
 body {
   color: var(--body--text);
   font-family: var(--body-font);


### PR DESCRIPTION
Setting a pixel font-size on the root makes it impossible for it to scale with the user's browser/os preferences. 16px is already the default so this declaration is not needed at all.