### PR TITLE
Fix links that are rendered on guest and sponsor pages

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -3094,6 +3094,12 @@
             "pump": "^3.0.0"
           }
         },
+        "normalize-url": {
+          "version": "6.1.0",
+          "resolved": "https://registry.npmjs.org/normalize-url/-/normalize-url-6.1.0.tgz",
+          "integrity": "sha512-DlL+XwOy3NxAQ8xuC0okPgK46iuVNAK01YN7RueYBqqFeGsBjV9XmCAzAdgt+667bCl5kPh9EqKKDwnaPG1I7A==",
+          "dev": true
+        },
         "pump": {
           "version": "3.0.0",
           "resolved": "https://registry.npmjs.org/pump/-/pump-3.0.0.tgz",
@@ -25226,10 +25232,9 @@
       "integrity": "sha512-6eZs5Ls3WtCisHWp9S2GUy8dqkpGi4BVSz3GaqiE6ezub0512ESztXUwUB6C6IKbQkY2Pnb/mD4WYojCRwcwLA=="
     },
     "normalize-url": {
-      "version": "6.1.0",
-      "resolved": "https://registry.npmjs.org/normalize-url/-/normalize-url-6.1.0.tgz",
-      "integrity": "sha512-DlL+XwOy3NxAQ8xuC0okPgK46iuVNAK01YN7RueYBqqFeGsBjV9XmCAzAdgt+667bCl5kPh9EqKKDwnaPG1I7A==",
-      "dev": true
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/normalize-url/-/normalize-url-8.0.0.tgz",
+      "integrity": "sha512-uVFpKhj5MheNBJRTiMZ9pE/7hD1QTeEvugSJW/OmLzAp78PB5O6adfMNTvmfKhXBkvCzC+rqifWcVYpGFwTjnw=="
     },
     "npm-package-arg": {
       "version": "8.1.5",

--- a/package.json
+++ b/package.json
@@ -22,6 +22,7 @@
     "astro": "^1.6.12",
     "astro-icon": "^0.8.0",
     "node-fetch": "^2.6.7",
+    "normalize-url": "^8.0.0",
     "open-props": "^1.5.1",
     "sass": "^1.56.1",
     "svelte": "^3.53.1",

--- a/src/pages/guest/[uid].astro
+++ b/src/pages/guest/[uid].astro
@@ -1,5 +1,6 @@
 ---
 import { Icon } from 'astro-icon';
+import normalizeUrl from 'normalize-url';
 import * as prismicH from '@prismicio/helpers';
 import Layout from '../../layouts/Layout.astro';
 import { getAllGuests } from '../../lib/prismicio';
@@ -42,10 +43,9 @@ const guestBioHTML = prismicH.asHTML(guest.data.guestBio);
 const topicDescriptionHTML = prismicH.asHTML(guest.data.topicDescription);
 
 // regex to turn https://alextrost.com/ or https://www.alextrost.com/ into alextrost.com and remove a trailing slash
-const guestWebsite = guest.data.websiteUrl?.replace(
-  /(https?:\/\/)?(www\.)?([^\/]+)\/?/,
-  '$3'
-);
+const guestWebsite = guest.data.websiteUrl ?
+	normalizeUrl(guest.data.websiteUrl, {stripProtocol: true}) :
+	'';
 ---
 
 <Layout

--- a/src/pages/guest/[uid].astro
+++ b/src/pages/guest/[uid].astro
@@ -44,8 +44,10 @@ const topicDescriptionHTML = prismicH.asHTML(guest.data.topicDescription);
 
 // Turn https://alextrost.com/ or https://www.alextrost.com/ into alextrost.com and remove a trailing slash
 const guestWebsite = guest.data.websiteUrl ?
-	normalizeUrl(guest.data.websiteUrl, {stripProtocol: true}) :
-	'';
+  normalizeUrl(guest.data.websiteUrl, {
+    stripProtocol: true, // remove "https://"
+    removeTrailingSlash: false // keeps trailing slash for subpaths (but removes it for root routes)
+  }) : '';
 ---
 
 <Layout

--- a/src/pages/guest/[uid].astro
+++ b/src/pages/guest/[uid].astro
@@ -42,7 +42,7 @@ for (let j = 1; j < 5; j++) {
 const guestBioHTML = prismicH.asHTML(guest.data.guestBio);
 const topicDescriptionHTML = prismicH.asHTML(guest.data.topicDescription);
 
-// regex to turn https://alextrost.com/ or https://www.alextrost.com/ into alextrost.com and remove a trailing slash
+// Turn https://alextrost.com/ or https://www.alextrost.com/ into alextrost.com and remove a trailing slash
 const guestWebsite = guest.data.websiteUrl ?
 	normalizeUrl(guest.data.websiteUrl, {stripProtocol: true}) :
 	'';

--- a/src/pages/guest/[uid].astro
+++ b/src/pages/guest/[uid].astro
@@ -98,12 +98,14 @@ const guestWebsite = guest.data.websiteUrl ?
             {guestWebsite}
           </span>
         </a>
-        <a href={guest.data.twitterUrl} class="guest-link">
-          <Icon name="mdi:twitter" class="link-icon" />
-          <span>
-            {guest.data.name}'s Twitter
-          </span>
-        </a>
+        {!!guest.data.twitterUrl && (
+          <a href={guest.data.twitterUrl} class="guest-link">
+            <Icon name="mdi:twitter" class="link-icon" />
+            <span>
+              {guest.data.name}'s Twitter
+            </span>
+          </a>
+        )}
       </div>
     </div>
 

--- a/src/pages/sponsor/[uid].astro
+++ b/src/pages/sponsor/[uid].astro
@@ -150,8 +150,7 @@ const descriptionHTML = prismicH.asHTML(sponsor.data.description);
   }
 
   .holiday-supporter-link {
-    display: grid;
-    grid-template-columns: auto 1fr;
+    display: flex;
     gap: var(--space-3xs);
     color: white;
     font-weight: 400;

--- a/src/pages/sponsor/[uid].astro
+++ b/src/pages/sponsor/[uid].astro
@@ -150,12 +150,14 @@ const descriptionHTML = prismicH.asHTML(sponsor.data.description);
   }
 
   .holiday-supporter-link {
-    display: flex;
+    display: grid;
+    grid-template-columns: auto 1fr;
     gap: var(--space-3xs);
     color: white;
     font-weight: 400;
     text-decoration-line: none;
     font-size: var(--step--1);
+    text-align: left;
   }
 
   .holiday-supporter-link:hover {


### PR DESCRIPTION
This PR does a few things:

1. Replaces our regex for normalizing URLs with a purpose-built library. This library handles cases our original regex doesn't handle, such as subpages. This fixes one active issue we have on the current site:
<img width="265" alt="chriscoyier.netbio/)" src="https://user-images.githubusercontent.com/18060369/206811322-462be495-da04-48cd-9291-89179e8c9f24.png">

With this library, this properly renders as `chriscoyier.net/bio`.

2. Conditionally renders the guest's Twitter link based on whether one is provided. Currently, Chris's Twitter doesn't seem to be coming in from Prismic, leading to an hrefless `<a>` getting rendered. The most correct fix in this case is for @a-trost to add Chris's Twitter into Prismic, but in the meantime, this is a nice safeguard just in case.
3. Fixes this spacing on sponsor pages.
<img width="368" alt="List of Netlify links, with a bunch of spacing between the link icon and the link text." src="https://user-images.githubusercontent.com/18060369/206811878-efb19e77-921d-49e4-89e6-f349c080ddcf.png">
