### PR TITLE
Expose `aria-current` on Team navlink

### DIFF
--- a/src/components/Logo.astro
+++ b/src/components/Logo.astro
@@ -1,8 +1,6 @@
 ---
-const pathname = new URL(Astro.request.url).pathname;
-const ariaCurrent = pathname === '/' ? 'page' : false;
-
 const isHomepage = Astro.url.pathname === '/';
+const ariaCurrent = isHomepage ? 'page' : false;
 
 /*
  There are two logos here.
@@ -36,7 +34,7 @@ const isHomepage = Astro.url.pathname === '/';
       </>
     ) : (
       <>
-        <span class="visually-hidden">Frontend Horse home</span>
+        <span class="visually-hidden">Holiday Snowtacular home</span>
 
         <svg
           width="618"

--- a/src/components/NavBar.astro
+++ b/src/components/NavBar.astro
@@ -1,13 +1,21 @@
 ---
 import Logo from './Logo.astro';
 import RegistrationButton from './RegistrationButton.astro';
+
+const {pathname} = Astro.url;
 ---
 
 <header role="banner">
   <nav>
     <a href="/#sponsors">Sponsors</a>
     <a href="/#guests">Guests</a>
-    <a href="/contributors" rel="prefetch">Team</a>
+    <a
+      href="/contributors"
+      rel="prefetch"
+      aria-current={pathname === '/contributors' ? 'page' : undefined}
+    >
+      Team
+    </a>
   </nav>
   <Logo />
   <div class="actions">


### PR DESCRIPTION
- When on `/contributors`, _Team_ link in navbar now has `aria-current="page"`
- Minor tweaks in the main logo link