### PR TITLE
Unset explicit WebP format on hero images

### DIFF
--- a/src/components/HeroParallax.astro
+++ b/src/components/HeroParallax.astro
@@ -19,13 +19,13 @@ import Sleigh from '../../public/images/header_elements/sleigh.png';
 		style='position: absolute; z-index:5; opacity: .3; scale: 1.2; translate: 0% 0%;'
 	/> -->
   <div class="header-composition">
-    <Image src={Sleigh} class="sleigh parallax-asset" alt="" width={420} format="webp" loading="eager" />
-    <Image src={Present} class="present parallax-asset" alt="" height={306} format="webp" loading="eager" />
-    <Image src={Bell} class="bell parallax-asset" alt="" height={120} format="webp" loading="eager" />
-    <Image src={Cursor} class="cursor parallax-asset" alt="" height={125} format="webp" loading="eager" />
-    <Image src={Hat} class="hat parallax-asset" alt="" height={113} format="webp" loading="eager" />
-    <Image src={Keyboard} class="keyboard parallax-asset" alt="" height={170} format="webp" loading="eager" />
-    <Image src={Sock} class="sock parallax-asset" alt="" height={190} format="webp" loading="eager" />
+    <Image src={Sleigh} class="sleigh parallax-asset" alt="" width={420} loading="eager" />
+    <Image src={Present} class="present parallax-asset" alt="" height={306} loading="eager" />
+    <Image src={Bell} class="bell parallax-asset" alt="" height={120} loading="eager" />
+    <Image src={Cursor} class="cursor parallax-asset" alt="" height={125} loading="eager" />
+    <Image src={Hat} class="hat parallax-asset" alt="" height={113} loading="eager" />
+    <Image src={Keyboard} class="keyboard parallax-asset" alt="" height={170} loading="eager" />
+    <Image src={Sock} class="sock parallax-asset" alt="" height={190} loading="eager" />
   </div>
 </div>
 


### PR DESCRIPTION
In #61, I changed the hero images to explicitly use WebP. Unfortunately, we've found enough people on old enough Safari versions that it's worth rolling back. #63 was an attempt to conditionally expose the right format for the browser with `<picture>`, but it got too finicky with how the images were being processed for animations. It's easier to just eat this loss, especially since the images fade in smoothly when they load in anyways.